### PR TITLE
feat: #34 startup REST API

### DIFF
--- a/cmd/auth-rest/go.mod
+++ b/cmd/auth-rest/go.mod
@@ -7,6 +7,7 @@ module github.com/trustbloc/hub-auth/cmd/auth-rest
 go 1.14
 
 require (
+	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.4
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v0.0.6

--- a/cmd/auth-rest/startcmd/start.go
+++ b/cmd/auth-rest/startcmd/start.go
@@ -28,6 +28,7 @@ import (
 	"github.com/trustbloc/hub-auth/pkg/restapi/operation"
 )
 
+// General parameters.
 const (
 	databaseTypeMemOption     = "mem"
 	databaseTypeCouchDBOption = "couchdb"
@@ -48,34 +49,69 @@ const (
 		" Alternatively, this can be set with the following environment variable: " + tlsCACertsEnvKey
 	tlsCACertsEnvKey = "AUTH_REST_TLS_CACERTS"
 
+	tlsServeCertPathFlagName  = "tls-serve-cert"
+	tlsServeCertPathFlagUsage = "Path to the server certificate to use when serving HTTPS." +
+		" Alternatively, this can be set with the following environment variable: " + tlsServeCertPathEnvKey
+	tlsServeCertPathEnvKey = "AUTH_REST_TLS_SERVE_CERT"
+
+	tlsServeKeyPathFlagName  = "tls-serve-key"
+	tlsServeKeyPathFlagUsage = "Path to the private key to use when serving HTTPS." +
+		" Alternatively, this can be set with the following environment variable: " + tlsServeKeyPathFlagEnvKey
+	tlsServeKeyPathFlagEnvKey = "AUTH_REST_TLS_SERVE_KEY"
+
 	logLevelFlagName        = "log-level"
-	logLevelEnvKey          = "LOG_LEVEL"
+	logLevelEnvKey          = "AUTH_REST_LOG_LEVEL"
 	logLevelFlagShorthand   = "l"
 	logLevelPrefixFlagUsage = "Default logging level to set. Supported options: CRITICAL, ERROR, WARNING, INFO, DEBUG." +
 		`Defaults to info if not set. Setting to debug may adversely impact performance. Alternatively, this can be ` +
 		"set with the following environment variable: " + logLevelEnvKey
 
 	databaseTypeFlagName      = "database-type"
-	databaseTypeEnvKey        = "DATABASE_TYPE"
+	databaseTypeEnvKey        = "AUTH_REST_DATABASE_TYPE"
 	databaseTypeFlagShorthand = "d"
 	databaseTypeFlagUsage     = "The type of database to use for storage. Supported options: mem, couchdb. " +
 		" Alternatively, this can be set with the following environment variable: " + databaseTypeEnvKey
 
 	databaseURLFlagName      = "database-url"
-	databaseURLEnvKey        = "DATABASE_URL"
+	databaseURLEnvKey        = "AUTH_REST_DATABASE_URL"
 	databaseURLFlagShorthand = "r"
 	databaseURLFlagUsage     = "The URL of the database. Not needed if using memstore." +
 		" For CouchDB, include the username:password@ text if required." +
 		" Alternatively, this can be set with the following environment variable: " + databaseURLEnvKey
 
 	databasePrefixFlagName      = "database-prefix"
-	databasePrefixEnvKey        = "DATABASE_PREFIX"
+	databasePrefixEnvKey        = "AUTH_REST_DATABASE_PREFIX"
 	databasePrefixFlagShorthand = "p"
 	databasePrefixFlagUsage     = "An optional prefix to be used when creating and retrieving databases." +
 		" This followed by an underscore will be prepended to any databases created by hub-auth. " +
 		" Alternatively, this can be set with the following environment variable: " + databasePrefixEnvKey
 
 	invalidDatabaseTypeErrMsg = "%s is not a valid database type. Run start --help to see the available options"
+)
+
+// OIDC parameters.
+const (
+	// assumed to be the same landing page for all callbacks from all OIDC providers
+	oidcCallbackURLFlagName  = "oidcCallbackURL"
+	oidcCallbackURLFlagUsage = "Base URL for the OIDC callback endpoint." +
+		" Alternatively, this can be set with the following environment variable: " + oidcCallbackURLEnvKey
+	oidcCallbackURLEnvKey = "AUTH_REST_OIDC_CALLBACK"
+
+	googleProviderFlagName  = "googleURL"
+	googleProviderFlagUsage = "URL for Google's OIDC provider (should be 'https://accounts.google.com')." +
+		" Alternatively, this can be set with the following environment variable: " + googleProviderEnvKey
+	googleProviderEnvKey = "AUTH_REST_GOOGLE_URL"
+
+	googleClientIDFlagName  = "googleClientID"
+	googleClientIDFlagUsage = "ClientID issued by Google for use with hub-auth." +
+		" For info on how to set it up: https://developers.google.com/identity/protocols/oauth2/openid-connect." +
+		" Alternatively, this can be set with the following environment variable: " + googleClientIDEnvKey
+	googleClientIDEnvKey = "AUTH_REST_GOOGLE_CLIENTID"
+
+	googleClientSecretFlagName  = "googleClientSecret"
+	googleClientSecretFlagUsage = "ClientSecret issued by Google for use with hub-auth." +
+		" Alternatively, this can be set with the following environment variable: " + googleClientSecretEnvKey
+	googleClientSecretEnvKey = "AUTH_REST_GOOGLE_CLIENTSECRET" // nolint:gosec
 )
 
 const (
@@ -86,13 +122,31 @@ const (
 var logger = log.New("auth-rest")
 
 type authRestParameters struct {
-	hostURL           string
-	tlsSystemCertPool bool
-	tlsCACerts        []string
-	logLevel          string
-	databaseType      string
-	databaseURL       string
-	databasePrefix    string
+	hostURL        string
+	logLevel       string
+	databaseType   string
+	databaseURL    string
+	databasePrefix string
+	tlsParams      *tlsParams
+	oidcParams     *oidcParams
+}
+
+type tlsParams struct {
+	useSystemCertPool bool
+	caCerts           []string
+	serveCertPath     string
+	serveKeyPath      string
+}
+
+type oidcParams struct {
+	baseCallbackURL string
+	google          *oidcProviderParams
+}
+
+type oidcProviderParams struct {
+	providerURL  string
+	clientID     string
+	clientSecret string
 }
 
 type healthCheckResp struct {
@@ -101,15 +155,15 @@ type healthCheckResp struct {
 }
 
 type server interface {
-	ListenAndServe(host string, router http.Handler) error
+	ListenAndServeTLS(host, certFile, keyFile string, router http.Handler) error
 }
 
 // HTTPServer represents an actual HTTP server implementation.
 type HTTPServer struct{}
 
-// ListenAndServe starts the server using the standard Go HTTP server implementation.
-func (s *HTTPServer) ListenAndServe(host string, router http.Handler) error {
-	return http.ListenAndServe(host, router)
+// ListenAndServeTLS starts the server using the standard Go HTTP server implementation.
+func (s *HTTPServer) ListenAndServeTLS(host, certFile, keyFile string, router http.Handler) error {
+	return http.ListenAndServeTLS(host, certFile, keyFile, router)
 }
 
 // GetStartCmd returns the Cobra start command.
@@ -143,7 +197,7 @@ func getAuthRestParameters(cmd *cobra.Command) (*authRestParameters, error) {
 		return nil, err
 	}
 
-	tlsSystemCertPool, tlsCACerts, err := getTLS(cmd)
+	tlsParams, err := getTLS(cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -174,48 +228,71 @@ func getAuthRestParameters(cmd *cobra.Command) (*authRestParameters, error) {
 		return nil, err
 	}
 
+	oidcParams, err := getOIDCParams(cmd)
+	if err != nil {
+		return nil, err
+	}
+
 	return &authRestParameters{
-		hostURL:           hostURL,
-		tlsSystemCertPool: tlsSystemCertPool,
-		tlsCACerts:        tlsCACerts,
-		logLevel:          loggingLevel,
-		databaseType:      databaseType,
-		databaseURL:       databaseURL,
-		databasePrefix:    databasePrefix,
+		hostURL:        hostURL,
+		tlsParams:      tlsParams,
+		logLevel:       loggingLevel,
+		databaseType:   databaseType,
+		databaseURL:    databaseURL,
+		databasePrefix: databasePrefix,
+		oidcParams:     oidcParams,
 	}, nil
 }
 
-func getTLS(cmd *cobra.Command) (bool, []string, error) {
-	tlsSystemCertPoolString, err := cmdutils.GetUserSetVarFromString(cmd, tlsSystemCertPoolFlagName,
-		tlsSystemCertPoolEnvKey, true)
-	if err != nil {
-		return false, nil, err
+func getTLS(cmd *cobra.Command) (*tlsParams, error) {
+	params := &tlsParams{
+		useSystemCertPool: false,
 	}
 
-	tlsSystemCertPool := false
-	if tlsSystemCertPoolString != "" {
-		tlsSystemCertPool, err = strconv.ParseBool(tlsSystemCertPoolString)
+	useSystemCertPoolString, err := cmdutils.GetUserSetVarFromString(cmd, tlsSystemCertPoolFlagName,
+		tlsSystemCertPoolEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if useSystemCertPoolString != "" {
+		params.useSystemCertPool, err = strconv.ParseBool(useSystemCertPoolString)
 		if err != nil {
-			return false, nil, err
+			return nil, err
 		}
 	}
 
-	tlsCACerts, err := cmdutils.GetUserSetVarFromArrayString(cmd, tlsCACertsFlagName, tlsCACertsEnvKey, true)
+	params.caCerts, err = cmdutils.GetUserSetVarFromArrayString(cmd, tlsCACertsFlagName, tlsCACertsEnvKey, true)
 	if err != nil {
-		return false, nil, err
+		return nil, err
 	}
 
-	return tlsSystemCertPool, tlsCACerts, nil
+	params.serveCertPath, err = cmdutils.GetUserSetVarFromString(cmd,
+		tlsServeCertPathFlagName, tlsServeCertPathEnvKey, true)
+	if err != nil {
+		return nil, err
+	}
+
+	params.serveKeyPath, err = cmdutils.GetUserSetVarFromString(cmd,
+		tlsServeKeyPathFlagName, tlsServeKeyPathFlagEnvKey, true)
+
+	return params, err
 }
 
 func createFlags(startCmd *cobra.Command) {
 	startCmd.Flags().StringP(hostURLFlagName, hostURLFlagShorthand, "", hostURLFlagUsage)
 	startCmd.Flags().StringP(tlsSystemCertPoolFlagName, "", "", tlsSystemCertPoolFlagUsage)
 	startCmd.Flags().StringArrayP(tlsCACertsFlagName, "", []string{}, tlsCACertsFlagUsage)
+	startCmd.Flags().StringP(tlsServeCertPathFlagName, "", "", tlsServeCertPathFlagUsage)
+	startCmd.Flags().StringP(tlsServeKeyPathFlagName, "", "", tlsServeKeyPathFlagUsage)
 	startCmd.Flags().StringP(logLevelFlagName, logLevelFlagShorthand, "", logLevelPrefixFlagUsage)
 	startCmd.Flags().StringP(databaseTypeFlagName, databaseTypeFlagShorthand, "", databaseTypeFlagUsage)
 	startCmd.Flags().StringP(databaseURLFlagName, databaseURLFlagShorthand, "", databaseURLFlagUsage)
 	startCmd.Flags().StringP(databasePrefixFlagName, databasePrefixFlagShorthand, "", databasePrefixFlagUsage)
+	startCmd.Flags().StringP(oidcCallbackURLFlagName, "", "", oidcCallbackURLFlagUsage)
+	startCmd.Flags().StringP(googleProviderFlagName, "", "", googleProviderFlagUsage)
+	startCmd.Flags().StringP(googleClientIDFlagName, "", "", googleClientIDFlagUsage)
+	startCmd.Flags().StringP(googleClientSecretFlagName, "", "", googleClientSecretFlagUsage)
 }
 
 func startAuthService(parameters *authRestParameters, srv server) error {
@@ -228,12 +305,12 @@ func startAuthService(parameters *authRestParameters, srv server) error {
 		return err
 	}
 
-	rootCAs, err := tlsutils.GetCertPool(parameters.tlsSystemCertPool, parameters.tlsCACerts)
+	rootCAs, err := tlsutils.GetCertPool(parameters.tlsParams.useSystemCertPool, parameters.tlsParams.caCerts)
 	if err != nil {
 		return err
 	}
 
-	logger.Infof("root ca's %v", rootCAs)
+	logger.Debugf("root ca's %v", rootCAs)
 
 	router := mux.NewRouter()
 
@@ -244,10 +321,20 @@ func startAuthService(parameters *authRestParameters, srv server) error {
 		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
 	}
 
-	// TODO #34 add the handlers from this controller to the router so that the endpoints are reachable
-	_, err = restapi.New(&operation.Config{TransientStoreProvider: memstore.NewProvider(), StoreProvider: provider})
+	svc, err := restapi.New(&operation.Config{
+		TransientStoreProvider: memstore.NewProvider(),
+		StoreProvider:          provider,
+		OIDCCallbackURL:        parameters.oidcParams.baseCallbackURL,
+		OIDCProviderURL:        parameters.oidcParams.google.providerURL,
+		OIDCClientID:           parameters.oidcParams.google.clientID,
+		OIDCClientSecret:       parameters.oidcParams.google.clientSecret,
+	})
 	if err != nil {
 		return err
+	}
+
+	for _, handler := range svc.GetOperations() {
+		router.HandleFunc(handler.Path(), handler.Handle()).Methods(handler.Method())
 	}
 
 	logger.Infof(`Starting hub-auth REST server with the following parameters: 
@@ -256,7 +343,52 @@ Database type: %s
 Database URL: %s
 Database prefix: %s`, parameters.hostURL, parameters.databaseType, parameters.databaseURL, parameters.databasePrefix)
 
-	return srv.ListenAndServe(parameters.hostURL, constructCORSHandler(router))
+	return srv.ListenAndServeTLS(
+		parameters.hostURL,
+		parameters.tlsParams.serveCertPath,
+		parameters.tlsParams.serveKeyPath,
+		constructCORSHandler(router),
+	)
+}
+
+func getOIDCParams(cmd *cobra.Command) (*oidcParams, error) {
+	params := &oidcParams{}
+
+	var err error
+
+	params.baseCallbackURL, err = cmdutils.GetUserSetVarFromString(cmd,
+		oidcCallbackURLFlagName, oidcCallbackURLEnvKey, false)
+	if err != nil {
+		return nil, err
+	}
+
+	params.google, err = getGoogleOIDCParams(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("misconfigured Google OIDC params: %w", err)
+	}
+
+	return params, nil
+}
+
+func getGoogleOIDCParams(cmd *cobra.Command) (*oidcProviderParams, error) {
+	params := &oidcProviderParams{}
+
+	var err error
+
+	params.providerURL, err = cmdutils.GetUserSetVarFromString(cmd, googleProviderFlagName, googleProviderEnvKey, false)
+	if err != nil {
+		return nil, err
+	}
+
+	params.clientID, err = cmdutils.GetUserSetVarFromString(cmd, googleClientIDFlagName, googleClientIDEnvKey, false)
+	if err != nil {
+		return nil, err
+	}
+
+	params.clientSecret, err = cmdutils.GetUserSetVarFromString(cmd,
+		googleClientSecretFlagName, googleClientSecretEnvKey, false)
+
+	return params, err
 }
 
 func setDefaultLogLevel(userLogLevel string) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/trustbloc/hub-auth
 
-go 1.13
+go 1.14
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible

--- a/pkg/internal/common/mockoidc/provider.go
+++ b/pkg/internal/common/mockoidc/provider.go
@@ -1,0 +1,59 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mockoidc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// StartProvider starts a new http endpoint serving a mock OpenID Connect configuration file and returns its base URL.
+// Useful for tests that include code paths that resolve the OIDC configuration file.
+func StartProvider(t *testing.T) string {
+	h := &testOIDCProvider{}
+	srv := httptest.NewServer(h)
+	h.baseURL = srv.URL
+
+	t.Cleanup(srv.Close)
+
+	return srv.URL
+}
+
+type oidcConfigJSON struct {
+	Issuer      string   `json:"issuer"`
+	AuthURL     string   `json:"authorization_endpoint"`
+	TokenURL    string   `json:"token_endpoint"`
+	JWKSURL     string   `json:"jwks_uri"`
+	UserInfoURL string   `json:"userinfo_endpoint"`
+	Algorithms  []string `json:"id_token_signing_alg_values_supported"`
+}
+
+type testOIDCProvider struct {
+	baseURL string
+}
+
+func (t *testOIDCProvider) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	response, err := json.Marshal(&oidcConfigJSON{
+		Issuer:      t.baseURL,
+		AuthURL:     fmt.Sprintf("%s/oauth2/auth", t.baseURL),
+		TokenURL:    fmt.Sprintf("%s/oauth2/token", t.baseURL),
+		JWKSURL:     fmt.Sprintf("%s/oauth2/certs", t.baseURL),
+		UserInfoURL: fmt.Sprintf("%s/oauth2/userinfo", t.baseURL),
+		Algorithms:  []string{"RS256"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = w.Write(response)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/test/bdd/features/healthcheck_api.feature
+++ b/test/bdd/features/healthcheck_api.feature
@@ -9,5 +9,5 @@
 Feature: health check
 
   Scenario:
-    When HTTP GET is sent to "http://localhost:8070/healthcheck"
+    When HTTP GET is sent to "https://localhost:8070/healthcheck"
     Then The "status" field in the response has the value "success"

--- a/test/bdd/fixtures/auth-rest/docker-compose.yml
+++ b/test/bdd/fixtures/auth-rest/docker-compose.yml
@@ -14,10 +14,66 @@ services:
       - AUTH_REST_HOST_URL=0.0.0.0:8070
       - AUTH_REST_TLS_CACERTS=/etc/tls/ec-cacert.pem
       - AUTH_REST_TLS_SYSTEMCERTPOOL=true
-      - DATABASE_TYPE=mem
+      - AUTH_REST_TLS_SERVE_CERT=/etc/tls/ec-pubCert.pem
+      - AUTH_REST_TLS_SERVE_KEY=/etc/tls/ec-key.pem
+      - AUTH_REST_DATABASE_TYPE=mem
+      - AUTH_REST_OIDC_CALLBACK=TODO   # https://github.com/trustbloc/hub-auth/issues/13
+      - AUTH_REST_GOOGLE_URL=http://mock.oidc.provider
+      - AUTH_REST_GOOGLE_CLIENTID=TODO # https://github.com/trustbloc/hub-auth/issues/9
+      - AUTH_REST_GOOGLE_CLIENTSECRET=TODO
     ports:
       - 8070:8070
     entrypoint: ""
-    command:  /bin/sh -c "auth-rest start"
+    command:  /bin/sh -c "sleep 10 && auth-rest start"
     volumes:
       - ../keys/tls:/etc/tls
+    depends_on:
+      - mock.oidc.provider
+    networks:
+      - bdd_test
+
+  mock.oidc.provider:
+    container_name: mock.oidc.provider
+    image: soluto/oidc-server-mock:0.2.2
+    ports:
+      - 4011:80
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      SERVER_OPTIONS_INLINE: |
+        {
+          "AccessTokenJwtType": "JWT",
+          "Discovery": {
+            "ShowKeySet": true
+          }
+        }
+      API_SCOPES_INLINE: |
+        [
+          "some-app-scope-1",
+          "some-app-scope-2"
+        ]
+      API_RESOURCES_INLINE: |
+        [
+          {
+            "Name": "some-app",
+            "Scopes": ["some-app-scope-1", "some-app-scope-2"]
+          }
+        ]
+      USERS_CONFIGURATION_INLINE: |
+        [
+          {
+            "SubjectId":"1",
+            "Username":"User1",
+            "Password":"pwd"
+          }
+        ]
+      CLIENTS_CONFIGURATION_PATH: /tmp/config/clients-config.json
+    volumes:
+      - ./oidc-config:/tmp/config:ro
+    networks:
+      bdd_test:
+        aliases:
+          - mock.oidc.provider
+
+networks:
+  bdd_test:
+    driver: bridge

--- a/test/bdd/fixtures/auth-rest/oidc-config/clients-config.json
+++ b/test/bdd/fixtures/auth-rest/oidc-config/clients-config.json
@@ -1,0 +1,46 @@
+[{
+  "ClientId": "implicit-mock-client",
+  "Description": "Client for implicit flow",
+  "AllowedGrantTypes": [
+    "implicit"
+  ],
+  "AllowAccessTokensViaBrowser": true,
+  "RedirectUris": [
+    "http://localhost:3000/auth/oidc",
+    "http://localhost:4004/auth/oidc"
+  ],
+  "AllowedScopes": [
+    "openid",
+    "profile",
+    "email"
+  ],
+  "IdentityTokenLifetime": 3600,
+  "AccessTokenLifetime": 3600
+},
+  {
+    "ClientId": "client-credentials-mock-client",
+    "ClientSecrets": [
+      "client-credentials-mock-client-secret"
+    ],
+    "Description": "Client for client credentials flow",
+    "AllowedGrantTypes": [
+      "client_credentials"
+    ],
+    "AllowedScopes": [
+      "some-app"
+    ],
+    "ClientClaimsPrefix": "",
+    "Claims": [
+      {
+        "Type": "string_claim",
+        "Value": "string_claim_value"
+      },
+      {
+        "Type": "json_claim",
+        "Value": "['value1', 'value2']",
+        "ValueType": "json"
+      }
+    ]
+
+  }
+]


### PR DESCRIPTION
closes #34

* wires the REST operations into the router
* fix: serve over HTTPS
* fix: disable unnecessary condition in operations.New()
* fix: incorrect environment variable names
* feat: google OIDC provider startup flags
* feat: mock oidc provider for BDD tests
* refactor: use t.Cleanup() in tests
* refactor: centralize mock oidc provider for unit tests
* chore: upgrade to go 1.14

Signed-off-by: George Aristy <george.aristy@securekey.com>