### PR TITLE
feat: #20 bootstrap data retrieve endpoint

### DIFF
--- a/cmd/auth-rest/startcmd/start_test.go
+++ b/cmd/auth-rest/startcmd/start_test.go
@@ -136,6 +136,52 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 			"Neither host-url (command line flag) nor AUTH_REST_HOST_URL (environment variable) have been set.",
 			err.Error())
 	})
+
+	t.Run("missing sds url arg", func(t *testing.T) {
+		oidcURL := mockOIDCProvider(t)
+		startCmd := GetStartCmd(&mockServer{})
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080",
+			"--" + logLevelFlagName, log.ParseString(log.DEBUG),
+			"--" + databaseTypeFlagName, "mem",
+			"--" + oidcCallbackURLFlagName, "http://example.com/oauth2/callback",
+			"--" + googleProviderFlagName, oidcURL,
+			"--" + googleClientIDFlagName, uuid.New().String(),
+			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
+		}
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), sdsURLFlagName)
+		require.Contains(t, err.Error(), sdsURLEnvKey)
+	})
+
+	t.Run("missing keyserver url arg", func(t *testing.T) {
+		oidcURL := mockOIDCProvider(t)
+		startCmd := GetStartCmd(&mockServer{})
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080",
+			"--" + logLevelFlagName, log.ParseString(log.DEBUG),
+			"--" + databaseTypeFlagName, "mem",
+			"--" + oidcCallbackURLFlagName, "http://example.com/oauth2/callback",
+			"--" + googleProviderFlagName, oidcURL,
+			"--" + googleClientIDFlagName, uuid.New().String(),
+			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + sdsURLFlagName, "http://sds.example.com",
+		}
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), keyServerURLFlagName)
+		require.Contains(t, err.Error(), keyServerURLEnvKey)
+	})
 }
 
 func TestStartCmdWithBlankEnvVar(t *testing.T) {
@@ -164,6 +210,8 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + googleProviderFlagName, oidcURL,
 			"--" + googleClientIDFlagName, uuid.New().String(),
 			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + sdsURLFlagName, "http://sds.example.com",
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 		}
 		startCmd.SetArgs(args)
 
@@ -185,6 +233,8 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + googleClientIDFlagName, uuid.New().String(),
 			"--" + googleClientSecretFlagName, uuid.New().String(),
 			"--" + logLevelFlagName, "INVALID",
+			"--" + sdsURLFlagName, "http://sds.example.com",
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 		}
 		startCmd.SetArgs(args)
 
@@ -207,6 +257,8 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + googleProviderFlagName, oidcURL,
 			"--" + googleClientIDFlagName, uuid.New().String(),
 			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + sdsURLFlagName, "http://sds.example.com",
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 		}
 		startCmd.SetArgs(args)
 
@@ -231,6 +283,8 @@ func TestStartCmdFailToCreateController(t *testing.T) {
 			"--" + googleProviderFlagName, oidcURL,
 			"--" + googleClientIDFlagName, uuid.New().String(),
 			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + sdsURLFlagName, "http://sds.example.com",
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 		}
 		startCmd.SetArgs(args)
 
@@ -257,6 +311,8 @@ func TestStartCmdInvalidDatabaseType(t *testing.T) {
 		"--" + googleProviderFlagName, oidcURL,
 		"--" + googleClientIDFlagName, uuid.New().String(),
 		"--" + googleClientSecretFlagName, uuid.New().String(),
+		"--" + sdsURLFlagName, "http://sds.example.com",
+		"--" + keyServerURLFlagName, "http://keyserver.example.com",
 	}
 	startCmd.SetArgs(args)
 
@@ -331,6 +387,10 @@ func setEnvVars(t *testing.T) {
 	err = os.Setenv(googleClientIDEnvKey, uuid.New().String())
 	require.NoError(t, err)
 	err = os.Setenv(googleClientSecretEnvKey, uuid.New().String())
+	require.NoError(t, err)
+	err = os.Setenv(sdsURLEnvKey, "http://sds.example.com")
+	require.NoError(t, err)
+	err = os.Setenv(keyServerURLEnvKey, "http://keyserver.examepl.com")
 	require.NoError(t, err)
 }
 

--- a/pkg/restapi/controller_test.go
+++ b/pkg/restapi/controller_test.go
@@ -43,7 +43,7 @@ func TestController_GetOperations(t *testing.T) {
 	require.NotNil(t, controller)
 
 	ops := controller.GetOperations()
-	require.Equal(t, 2, len(ops))
+	require.Equal(t, 3, len(ops))
 }
 
 func config(t *testing.T) *operation.Config {

--- a/pkg/restapi/operation/models.go
+++ b/pkg/restapi/operation/models.go
@@ -1,0 +1,18 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package operation
+
+type createOIDCRequestResponse struct {
+	Request string `json:"request"`
+}
+
+type bootstrapData struct {
+	SDSURL            string   `json:"sdsURL"`
+	SDSPrimaryVaultID string   `json:"sdsPrimaryVaultID"`
+	KeyServerURL      string   `json:"keyServerURL"`
+	KeyStoreIDs       []string `json:"keyStoreIDs"`
+}

--- a/test/bdd/fixtures/auth-rest/docker-compose.yml
+++ b/test/bdd/fixtures/auth-rest/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - AUTH_REST_GOOGLE_URL=http://mock.oidc.provider
       - AUTH_REST_GOOGLE_CLIENTID=TODO # https://github.com/trustbloc/hub-auth/issues/9
       - AUTH_REST_GOOGLE_CLIENTSECRET=TODO
+      - AUTH_REST_SDS_URL=TODO        # onboard user: https://github.com/trustbloc/hub-auth/issues/38
+      - AUTH_REST_KEYSERVER_URL=TODO  # onboard user: https://github.com/trustbloc/hub-auth/issues/38
     ports:
       - 8070:8070
     entrypoint: ""


### PR DESCRIPTION
closes #20

This PR depends on PR #43 where the user's profile is stored to the transient store and the user is redirected to the UI with a handle in the `up` query parameter. This PR reuses that query parameter to fetch the same user bootstrap data.

Two new startup parameters were added: SDS URL and Key Server URL.

Signed-off-by: George Aristy <george.aristy@securekey.com>