### PR TITLE
feat: GET and POST /secret

### DIFF
--- a/cmd/auth-rest/startcmd/start_test.go
+++ b/cmd/auth-rest/startcmd/start_test.go
@@ -185,6 +185,30 @@ func TestStartCmdWithMissingArg(t *testing.T) {
 		require.Contains(t, err.Error(), keyServerURLFlagName)
 		require.Contains(t, err.Error(), keyServerURLEnvKey)
 	})
+
+	t.Run("missing secrets token", func(t *testing.T) {
+		oidcURL := mockOIDCProvider(t)
+		startCmd := GetStartCmd(&mockServer{})
+
+		args := []string{
+			"--" + hostURLFlagName, "localhost:8080",
+			"--" + logLevelFlagName, log.ParseString(log.DEBUG),
+			"--" + databaseTypeFlagName, "mem",
+			"--" + oidcCallbackURLFlagName, "http://example.com/oauth2/callback",
+			"--" + googleProviderFlagName, oidcURL,
+			"--" + googleClientIDFlagName, uuid.New().String(),
+			"--" + googleClientSecretFlagName, uuid.New().String(),
+			"--" + sdsURLFlagName, "http://sds.example.com",
+			"--" + keyServerURLFlagName, "http://keyserver.example.com",
+			"--" + hydraURLFlagName, "http://hydra.example.com",
+		}
+		startCmd.SetArgs(args)
+
+		err := startCmd.Execute()
+
+		require.Error(t, err)
+		require.EqualError(t, err, "Neither secrets-api-token (command line flag) nor AUTH_REST_API_TOKEN (environment variable) have been set.") // nolint:lll
+	})
 }
 
 func TestStartCmdWithBlankEnvVar(t *testing.T) {
@@ -236,6 +260,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + sdsURLFlagName, "http://sds.example.com",
 			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 			"--" + hydraURLFlagName, "http://hydra.example.com",
+			"--" + secretsAPITokenFlagName, uuid.New().String(),
 		}
 		startCmd.SetArgs(args)
 
@@ -260,6 +285,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + sdsURLFlagName, "http://sds.example.com",
 			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 			"--" + hydraURLFlagName, "http://hydra.example.com",
+			"--" + secretsAPITokenFlagName, uuid.New().String(),
 		}
 		startCmd.SetArgs(args)
 
@@ -285,6 +311,7 @@ func TestStartCmdValidArgs(t *testing.T) {
 			"--" + sdsURLFlagName, "http://sds.example.com",
 			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 			"--" + hydraURLFlagName, "http://hydra.example.com",
+			"--" + secretsAPITokenFlagName, uuid.New().String(),
 		}
 		startCmd.SetArgs(args)
 
@@ -385,6 +412,7 @@ func TestStartCmdFailToCreateController(t *testing.T) {
 			"--" + sdsURLFlagName, "http://sds.example.com",
 			"--" + keyServerURLFlagName, "http://keyserver.example.com",
 			"--" + hydraURLFlagName, "http://hydra.example.com",
+			"--" + secretsAPITokenFlagName, uuid.New().String(),
 		}
 		startCmd.SetArgs(args)
 
@@ -414,6 +442,7 @@ func TestStartCmdInvalidDatabaseType(t *testing.T) {
 		"--" + sdsURLFlagName, "http://sds.example.com",
 		"--" + keyServerURLFlagName, "http://keyserver.example.com",
 		"--" + hydraURLFlagName, "http://hydra.example.com",
+		"--" + secretsAPITokenFlagName, uuid.New().String(),
 	}
 	startCmd.SetArgs(args)
 
@@ -496,6 +525,8 @@ func setEnvVars(t *testing.T) {
 	err = os.Setenv(keyServerURLEnvKey, "http://keyserver.examepl.com")
 	require.NoError(t, err)
 	err = os.Setenv(hydraURLEnvKey, "http://hydra.example.com")
+	require.NoError(t, err)
+	err = os.Setenv(secretsAPITokenEnvKey, uuid.New().String())
 	require.NoError(t, err)
 }
 

--- a/pkg/restapi/operation/models.go
+++ b/pkg/restapi/operation/models.go
@@ -23,3 +23,13 @@ type UpdateBootstrapDataRequest struct {
 	SDSPrimaryVaultID string   `json:"sdsPrimaryVaultID,omitempty"`
 	KeyStoreIDs       []string `json:"keyStoreIDs,omitempty"`
 }
+
+// SetSecretRequest is the payload of a request to set a secret.
+type SetSecretRequest struct {
+	Secret []byte `json:"secret"`
+}
+
+// GetSecretResponse is the response's payload to a request to get a secret.
+type GetSecretResponse struct {
+	Secret string `json:"secret"`
+}

--- a/test/bdd/bddtests_test.go
+++ b/test/bdd/bddtests_test.go
@@ -8,8 +8,6 @@ package bdd
 import (
 	"flag"
 	"fmt"
-	"github.com/trustbloc/hub-auth/test/bdd/pkg/bootstrap"
-	"github.com/trustbloc/hub-auth/test/bdd/pkg/login"
 	"os"
 	"strconv"
 	"strings"
@@ -19,8 +17,11 @@ import (
 	"github.com/cucumber/godog"
 
 	"github.com/trustbloc/hub-auth/test/bdd/dockerutil"
+	"github.com/trustbloc/hub-auth/test/bdd/pkg/bootstrap"
 	"github.com/trustbloc/hub-auth/test/bdd/pkg/common"
 	bddctx "github.com/trustbloc/hub-auth/test/bdd/pkg/context"
+	"github.com/trustbloc/hub-auth/test/bdd/pkg/login"
+	"github.com/trustbloc/hub-auth/test/bdd/pkg/secrets"
 )
 
 func TestMain(m *testing.M) {
@@ -129,4 +130,5 @@ func FeatureContext(s *godog.Suite) {
 	common.NewSteps(bddContext).RegisterSteps(s)
 	login.NewSteps(bddContext).RegisterSteps(s)
 	bootstrap.NewSteps(bddContext).RegisterSteps(s)
+	secrets.NewSteps(bddContext).RegisterSteps(s)
 }

--- a/test/bdd/features/secrets.feature
+++ b/test/bdd/features/secrets.feature
@@ -1,0 +1,21 @@
+#
+# Copyright SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+@all
+@secrets
+Feature: Bootstrap data
+  Background: Wallet login
+    Given a user logged in with their wallet
+
+  Scenario: Put secret
+    When the wallet stores the secret in hub-auth
+     And the key server queries hub-auth for the secret
+    Then the key server receives the secret
+
+  Scenario: User attempts to store secret twice
+    When the wallet executes an HTTP POST on the bootstrap endpoint
+    And the wallet executes an HTTP GET on the bootstrap endpoint
+    Then hub-auth returns the updated bootstrap data

--- a/test/bdd/fixtures/auth-rest/docker-compose.yml
+++ b/test/bdd/fixtures/auth-rest/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - AUTH_REST_KEYSERVER_URL=https://TODO.keyserver.org/  # onboard user: https://github.com/trustbloc/hub-auth/issues/38
       - AUTH_REST_HYDRA_URL=https://auth.rest.hydra.example.com:4445
       - AUTH_REST_LOG_LEVEL=DEBUG
+      - AUTH_REST_API_TOKEN=test_token
     ports:
       - 8070:8070
     entrypoint: ""

--- a/test/bdd/pkg/secrets/mock_key_server.go
+++ b/test/bdd/pkg/secrets/mock_key_server.go
@@ -1,0 +1,91 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secrets
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/trustbloc/hub-auth/pkg/restapi/operation"
+	"io/ioutil"
+	"net/http"
+)
+
+func NewMockKeyServer(token string, tlsConfig *tls.Config) *MockKeyServer {
+	return &MockKeyServer{
+		ApiToken: token,
+		TLSConfig: tlsConfig,
+	}
+}
+
+type MockKeyServer struct {
+	ApiToken string
+	TLSConfig *tls.Config
+	UserSecret   string
+}
+
+func (m *MockKeyServer) FetchSecretShare(endpoint string) error {
+	request, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create http request: %w", err)
+	}
+
+	m.addToken(request)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: m.TLSConfig,
+		},
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to invoke %s: %w", endpoint, err)
+	}
+
+	defer func() {
+		closeErr := response.Body.Close()
+		if closeErr != nil {
+			fmt.Printf("WARNING - failed to close response body: %s\n", closeErr.Error())
+		}
+	}()
+
+	if response.StatusCode != http.StatusOK {
+		msg, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			fmt.Printf("WARNING - failed to read response body: %s\n", err.Error())
+		}
+
+		return fmt.Errorf(
+			"unexpected response: code=%d msg=%s", response.StatusCode, msg,
+		)
+	}
+
+	result := &operation.GetSecretResponse{}
+
+	err = json.NewDecoder(response.Body).Decode(result)
+	if err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(result.Secret)
+	if err != nil {
+		return fmt.Errorf("failed to decode secret: %w", err)
+	}
+
+	m.UserSecret = string(decoded)
+
+	return nil
+}
+
+func (m *MockKeyServer) addToken(r *http.Request) {
+	r.Header.Set(
+		"authorization",
+		fmt.Sprintf("Bearer %s", base64.StdEncoding.EncodeToString([]byte(m.ApiToken))),
+	)
+}

--- a/test/bdd/pkg/secrets/steps.go
+++ b/test/bdd/pkg/secrets/steps.go
@@ -1,0 +1,81 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/cucumber/godog"
+	"github.com/trustbloc/hub-auth/test/bdd/pkg/login"
+
+	bddctx "github.com/trustbloc/hub-auth/test/bdd/pkg/context"
+)
+
+const (
+	secretsEndpoint = login.HUB_AUTH_HOST + "/secret"
+	apiToken        = "test_token"
+)
+
+func NewSteps(ctx *bddctx.BDDContext) *Steps {
+	return &Steps{
+		ctx:       ctx,
+		keyServer: NewMockKeyServer(apiToken, ctx.TLSConfig()),
+	}
+}
+
+type Steps struct {
+	ctx       *bddctx.BDDContext
+	wallet    *login.MockWallet
+	keyServer *MockKeyServer
+}
+
+func (s *Steps) RegisterSteps(gs *godog.Suite) {
+	gs.Step("a user logged in with their wallet", s.userLogin)
+	gs.Step("the wallet stores the secret in hub-auth", s.walletStoresSecretInHubAuth)
+	gs.Step("the key server queries hub-auth for the secret", s.keyServerFetchesSecret)
+	gs.Step("the key server receives the secret", s.keyServerReceivesTheSameSecret)
+}
+
+func (s *Steps) userLogin() error {
+	var err error
+
+	s.wallet, err = login.NewSteps(s.ctx).NewWalletLogin()
+	if err != nil {
+		return fmt.Errorf("wallet failed to login: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Steps) walletStoresSecretInHubAuth() error {
+	err := s.wallet.CreateAndPushSecretToHubAuth(secretsEndpoint)
+	if err != nil {
+		return fmt.Errorf("wallet failed to store secret in hub-auth: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Steps) keyServerFetchesSecret() error {
+	err := s.keyServer.FetchSecretShare(fmt.Sprintf("%s?sub=%s", secretsEndpoint, s.wallet.UserData.Sub))
+	if err != nil {
+		return fmt.Errorf("key server failed to fetch the user's secret: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Steps) keyServerReceivesTheSameSecret() error {
+	if s.keyServer.UserSecret != s.wallet.Secret {
+		return fmt.Errorf(
+			"keyServer received an unexpected secret: expected %s got %s",
+			s.wallet.Secret, s.keyServer.UserSecret,
+		)
+	}
+
+	return nil
+}


### PR DESCRIPTION
* User can push secret share once (authz: oauth2)
* KeyServer can fetch the secret share many times (authz: static api token)

Signed-off-by: George Aristy <george.aristy@securekey.com>