### PR TITLE
refactor: bootstrap data

### DIFF
--- a/pkg/bootstrap/user/userprofile.go
+++ b/pkg/bootstrap/user/userprofile.go
@@ -15,10 +15,9 @@ import (
 
 // Profile is the user's bootstrap profile.
 type Profile struct {
-	ID                string
-	AAGUID            string // TODO: create user device store https://github.com/trustbloc/hub-auth/issues/58
-	SDSPrimaryVaultID string
-	KeyStoreIDs       []string
+	ID     string
+	AAGUID string // TODO: create user device store https://github.com/trustbloc/hub-auth/issues/58
+	Data   map[string]string
 }
 
 // ProfileStore is the user Profile CRUD API.

--- a/pkg/bootstrap/user/userprofile_test.go
+++ b/pkg/bootstrap/user/userprofile_test.go
@@ -24,9 +24,12 @@ func TestNewStore(t *testing.T) {
 func TestSave(t *testing.T) {
 	t.Run("saves profile", func(t *testing.T) {
 		expected := &Profile{
-			ID:                uuid.New().String(),
-			SDSPrimaryVaultID: uuid.New().String(),
-			KeyStoreIDs:       []string{uuid.New().String()},
+			ID:     uuid.New().String(),
+			AAGUID: uuid.New().String(),
+			Data: map[string]string{
+				"my vault": uuid.New().String(),
+				"keystore": uuid.New().String(),
+			},
 		}
 
 		store := &mockstore.MockStore{
@@ -55,9 +58,12 @@ func TestSave(t *testing.T) {
 func TestGet(t *testing.T) {
 	t.Run("fetches profile", func(t *testing.T) {
 		expected := &Profile{
-			ID:                uuid.New().String(),
-			SDSPrimaryVaultID: uuid.New().String(),
-			KeyStoreIDs:       []string{uuid.New().String()},
+			ID:     uuid.New().String(),
+			AAGUID: uuid.New().String(),
+			Data: map[string]string{
+				"my vault": uuid.New().String(),
+				"keystore": uuid.New().String(),
+			},
 		}
 		store := &mockstore.MockStore{
 			Store: map[string][]byte{

--- a/pkg/restapi/operation/models.go
+++ b/pkg/restapi/operation/models.go
@@ -8,10 +8,11 @@ package operation
 
 // BootstrapData is the user's bootstrap data.
 type BootstrapData struct {
-	SDSURL            string   `json:"sdsURL"`
-	SDSPrimaryVaultID string   `json:"sdsPrimaryVaultID"`
-	KeyServerURL      string   `json:"keyServerURL"`
-	KeyStoreIDs       []string `json:"keyStoreIDs"`
+	DocumentSDSVaultURL string            `json:"documentSDSURL"`
+	KeySDSVaultURL      string            `json:"keySDSURL"`
+	AuthZKeyServerURL   string            `json:"authzKeyServerURL"`
+	OpsKeyServerURL     string            `json:"opsKeyServerURL"`
+	Data                map[string]string `json:"entries,omitempty"`
 }
 
 type oidcClaims struct {
@@ -20,8 +21,7 @@ type oidcClaims struct {
 
 // UpdateBootstrapDataRequest is a request to update bootstrap data.
 type UpdateBootstrapDataRequest struct {
-	SDSPrimaryVaultID string   `json:"sdsPrimaryVaultID,omitempty"`
-	KeyStoreIDs       []string `json:"keyStoreIDs,omitempty"`
+	Data map[string]string `json:"data"`
 }
 
 // SetSecretRequest is the payload of a request to set a secret.

--- a/test/bdd/features/secrets.feature
+++ b/test/bdd/features/secrets.feature
@@ -6,7 +6,7 @@
 
 @all
 @secrets
-Feature: Bootstrap data
+Feature: Secrets
   Background: Wallet login
     Given a user logged in with their wallet
 
@@ -16,6 +16,6 @@ Feature: Bootstrap data
     Then the key server receives the secret
 
   Scenario: User attempts to store secret twice
-    When the wallet executes an HTTP POST on the bootstrap endpoint
-    And the wallet executes an HTTP GET on the bootstrap endpoint
-    Then hub-auth returns the updated bootstrap data
+    When the wallet stores the secret in hub-auth
+     And the wallet attempts to store the secret again
+    Then hub-auth returns an error

--- a/test/bdd/fixtures/auth-rest/docker-compose.yml
+++ b/test/bdd/fixtures/auth-rest/docker-compose.yml
@@ -23,8 +23,10 @@ services:
       - AUTH_REST_GOOGLE_URL=https://third.party.oidc.provider.example.com:5555/
       - AUTH_REST_GOOGLE_CLIENTID=hub-auth # https://github.com/trustbloc/hub-auth/issues/9
       - AUTH_REST_GOOGLE_CLIENTSECRET=hub-auth-secret
-      - AUTH_REST_SDS_URL=https://TODO.sds.org/              # onboard user: https://github.com/trustbloc/hub-auth/issues/38
-      - AUTH_REST_KEYSERVER_URL=https://TODO.keyserver.org/  # onboard user: https://github.com/trustbloc/hub-auth/issues/38
+      - AUTH_REST_SDS_DOCS_URL=https://TODO.docs.sds.org/              # onboard user: https://github.com/trustbloc/hub-auth/issues/38
+      - AUTH_REST_SDS_OPSKEYS_URL=https://TODO.keys.sds.org/
+      - AUTH_REST_KEYSERVER_AUTH_URL=https://TODO.auth.keyserver.org/  # onboard user: https://github.com/trustbloc/hub-auth/issues/38
+      - AUTH_REST_KEYSERVER_OPS_URL=https://TODO.ops.keyserver.org/
       - AUTH_REST_HYDRA_URL=https://auth.rest.hydra.example.com:4445
       - AUTH_REST_LOG_LEVEL=DEBUG
       - AUTH_REST_API_TOKEN=test_token


### PR DESCRIPTION
* bootstrap data has two SDS urls and two key server URLS
* user data in bootstrap data is now a generic map
* fix BDD test scenario for secrets
* new startup flag for external dependency timeout on startup

Signed-off-by: George Aristy <george.aristy@securekey.com>