### PR TITLE
test: expose PushSecretToHubAuth method of MockWallet

### DIFF
--- a/test/bdd/pkg/login/mock_wallet.go
+++ b/test/bdd/pkg/login/mock_wallet.go
@@ -142,7 +142,13 @@ func (m *MockWallet) UpdateBootstrapData(endpoint string, update *operation.Upda
 }
 
 func (m *MockWallet) CreateAndPushSecretToHubAuth(endpoint string) error {
-	m.Secret = uuid.New().String()
+	secret := uuid.New().String()
+
+	return m.PushSecretToHubAuth(endpoint, secret)
+}
+
+func (m *MockWallet) PushSecretToHubAuth(endpoint, secret string) error {
+	m.Secret = secret
 
 	payload, err := json.Marshal(&operation.SetSecretRequest{
 		Secret: []byte(m.Secret),


### PR DESCRIPTION
Adds public `PushSecretToHubAuth` method to `MockWallet`, so the secret can be specified from the outside. It should greatly help with reusing that functionality in other BDD tests.

Signed-off-by: Andriy Holovko <andriy.holovko@gmail.com>