### PR TITLE
fix: Remove hard-coded TLS ver requirement

### DIFF
--- a/cmd/auth-rest/startcmd/start.go
+++ b/cmd/auth-rest/startcmd/start.go
@@ -434,7 +434,7 @@ func startAuthService(parameters *authRestParameters, srv server) error {
 			OpsKeyServerURL:     parameters.bootstrapParams.opsKeyServerURL,
 		},
 		DeviceRootCerts: parameters.devicecertParams.caCerts,
-		TLSConfig:       &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS13},
+		TLSConfig:       &tls.Config{RootCAs: rootCAs},
 		UIEndpoint:      uiEndpoint,
 		Cookies: &operation.CookieConfig{
 			AuthKey: parameters.keys.sessionCookieAuthKey,

--- a/pkg/restapi/common/hydra/client.go
+++ b/pkg/restapi/common/hydra/client.go
@@ -44,8 +44,7 @@ func NewClient(hydraURL *url.URL, rootCAs *x509.CertPool) *Client {
 			},
 		).Admin,
 		httpClient: &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{
-			RootCAs:    rootCAs,
-			MinVersion: tls.VersionTLS13,
+			RootCAs: rootCAs,
 		}}},
 	}
 }

--- a/test/bdd/mock/loginconsent/main.go
+++ b/test/bdd/mock/loginconsent/main.go
@@ -102,7 +102,6 @@ func loadConfig() (*config, error) {
 		serveKeyFile:  serveKeyPath,
 		tlsConfig: &tls.Config{
 			RootCAs:    rootCACerts,
-			MinVersion: tls.VersionTLS13,
 		},
 		store: store,
 	}, nil

--- a/test/bdd/pkg/context/context.go
+++ b/test/bdd/pkg/context/context.go
@@ -24,7 +24,7 @@ func NewBDDContext(caCertPath string) (*BDDContext, error) {
 		return nil, err
 	}
 
-	return &BDDContext{tlsConfig: &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS13}}, nil
+	return &BDDContext{tlsConfig: &tls.Config{RootCAs: rootCAs}}, nil
 }
 
 // TLSConfig return tls config.


### PR DESCRIPTION
TLS 1.3 is still not widely deployed yet (eg. AWS Elastic Load
Balancers). Instead of downgrading *enforcement* of TLS ver in the
application, it's better to remove this concern entirely from the
application's code and instead leave that up to proxy and external
service configurations.

Signed-off-by: George Aristy <george.aristy@securekey.com>